### PR TITLE
fix to regex to match ALL apple touch icon permutations

### DIFF
--- a/lib/quiet_safari.rb
+++ b/lib/quiet_safari.rb
@@ -5,7 +5,7 @@ module QuietSafari
   class Engine < ::Rails::Engine
     config.quiet_safari = true
 
-    APPL = /apple-touch-icon(-precomposed)?\.png/
+    APPL = /apple-touch-icon(-precomposed)?.*/
     KEY = 'quiet_safari.old_rails_log_level'
 
     initializer 'quiet_safari' do |app|
@@ -14,7 +14,7 @@ module QuietSafari
       Rails::Rack::Logger.class_eval do
         def call_with_quiet_safari(env)
           begin
-            if Rails.application.config.quiet_safari && env['PATH_INFO'] =~ APPL
+            if Rails.application.config.quiet_safari and env['PATH_INFO'] =~ APPL
               env[KEY]           = Rails.logger.level
               Rails.logger.level = Logger::UNKNOWN
             end

--- a/lib/quiet_safari/version.rb
+++ b/lib/quiet_safari/version.rb
@@ -2,7 +2,7 @@ module QuietSafari
   class Version
     MAJOR = 1
     MINOR = 0
-    PATCH = 1
+    PATCH = 0
 
     def self.to_s
       [MAJOR, MINOR, PATCH].join('.')

--- a/lib/quiet_safari/version.rb
+++ b/lib/quiet_safari/version.rb
@@ -2,7 +2,7 @@ module QuietSafari
   class Version
     MAJOR = 1
     MINOR = 0
-    PATCH = 0
+    PATCH = 1
 
     def self.to_s
       [MAJOR, MINOR, PATCH].join('.')

--- a/test/quiet_safari_test.rb
+++ b/test/quiet_safari_test.rb
@@ -45,8 +45,20 @@ class QuietSafariTest < QuietSafari::TestCase
     assert_empty log.string
   end
 
+  def test_requesting_apple_touch_icon_152_quiet
+    get '/apple-touch-icon-152x152.png'
+
+    assert_empty log.string
+  end
+
   def test_requesting_apple_touch_icon_precomposed_quiet
     get '/apple-touch-icon-precomposed.png'
+
+    assert_empty log.string
+  end
+
+  def test_requesting_apple_touch_icon_precomposed_quiet
+    get '/apple-touch-icon-152x152-precomposed.png'
 
     assert_empty log.string
   end


### PR DESCRIPTION
Default regex would only match apple-touch-icon.png and apple-touch-icon-precomposed.png.  Added trailing character match to match any of the ridiculous apple-touch-icon-xxx permutations.  Stop chasing Safari apple touch icons and just say NO.
