### PR TITLE
expanding regex to match sizes in icon path

### DIFF
--- a/lib/quiet_safari.rb
+++ b/lib/quiet_safari.rb
@@ -5,7 +5,7 @@ module QuietSafari
   class Engine < ::Rails::Engine
     config.quiet_safari = true
 
-    APPL = /apple-touch-icon(-precomposed)?\.png/
+    APPL = /apple-touch-icon(?:-\d+x\d+)?(?:-precomposed)?\.png/
     KEY = 'quiet_safari.old_rails_log_level'
 
     initializer 'quiet_safari' do |app|

--- a/test/quiet_safari_test.rb
+++ b/test/quiet_safari_test.rb
@@ -45,10 +45,26 @@ class QuietSafariTest < QuietSafari::TestCase
     assert_empty log.string
   end
 
+  def test_requesting_apple_touch_icon_sizes_quiet
+    ['120', '152'].each do |size|
+      get "/apple-touch-icon-#{size}x#{size}.png"
+
+      assert_empty log.string
+    end
+  end
+
   def test_requesting_apple_touch_icon_precomposed_quiet
     get '/apple-touch-icon-precomposed.png'
 
     assert_empty log.string
+  end
+
+  def test_requesting_apple_touch_icon_sizes_precomposed_quiet
+    ['120', '152'].each do |size|
+      get "/apple-touch-icon-#{size}x#{size}-precomposed.png"
+
+      assert_empty log.string
+    end
   end
 
   def test_multithreaded


### PR DESCRIPTION
Iterating on https://github.com/davidcelis/quiet_safari/pull/2 

Seeing the following icons getting requested:
```
/apple-touch-icon-120x120.png
/apple-touch-icon-120x120-precomposed.png
/apple-touch-icon-152x152.png
/apple-touch-icon-152x152-precomposed.png
```

Tested regex on http://rubular.com/ and unit tests. Thanks!